### PR TITLE
Look for requirements.yml or .txt relative to playbook file

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -11,8 +11,7 @@
 
 ANSIBLE_PLAYBOOK=$1
 PLAYBOOK_DIR=${ANSIBLE_PLAYBOOK%/*}
-ROLE_REQUIREMENTS=$(find /vagrant/$PLAYBOOK_DIR -regextype posix-extended\
-  -iregex ".*/requirements.(txt|yml)" )
+ROLE_REQUIREMENTS=$(find /vagrant/$PLAYBOOK_DIR -name "requirements.yml" -o -name "requirements.txt" )
 
 # Detect package management system.
 YUM=$(which yum)

--- a/windows.sh
+++ b/windows.sh
@@ -10,6 +10,9 @@
 # export {http,https,ftp}_proxy='http://username:password@proxy-host:80'
 
 ANSIBLE_PLAYBOOK=$1
+PLAYBOOK_DIR=${ANSIBLE_PLAYBOOK%/*}
+ROLE_REQUIREMENTS=$(find /vagrant/$PLAYBOOK_DIR -regextype posix-extended\
+  -iregex ".*/requirements.(txt|yml)" )
 
 # Detect package management system.
 YUM=$(which yum)
@@ -48,10 +51,9 @@ if [ ! -f /usr/bin/ansible ]; then
 fi
 
 # Install Ansible roles from requirements file, if available.
-if [ -f /vagrant/requirements.txt ]; then
-  sudo ansible-galaxy install -r /vagrant/requirements.txt
-elif [-f /vagrant/requirements.yml ]; then
-  sudo ansible-galaxy install -r /vagrant/requirements.yml
+if [ -f $ROLE_REQUIREMENTS ]; then
+  echo "Found Ansible role file at $ROLE_REQUIREMENTS"
+  sudo ansible-galaxy install -r ${ROLE_REQUIREMENTS}
 fi
 
 # Run the playbook.


### PR DESCRIPTION
First, thanks for the project! This and your blog post saved me quite a bit of time. 

The readme mentions you should place the requirements file in the same directory as your playbook, but if you follow the conventions in your example vagrant file it will never find it in the provisioning or whatever you use subfolder.
