### PR TITLE
Fix space missing in requirement condition

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -50,7 +50,7 @@ fi
 # Install Ansible roles from requirements file, if available.
 if [ -f /vagrant/requirements.txt ]; then
   sudo ansible-galaxy install -r /vagrant/requirements.txt
-elif [-f /vagrant/requirements.yml ]; then
+elif [ -f /vagrant/requirements.yml ]; then
   sudo ansible-galaxy install -r /vagrant/requirements.yml
 fi
 


### PR DESCRIPTION
The missing space gave me this error: `/tmp/vagrant-shell: line 53: [-f: command not found`.