### PR TITLE
Protect $ROLE_REQUIREMENTS with quotes.

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -50,9 +50,9 @@ if [ ! -f /usr/bin/ansible ]; then
 fi
 
 # Install Ansible roles from requirements file, if available.
-if [ -f $ROLE_REQUIREMENTS ]; then
+if [ -f "$ROLE_REQUIREMENTS" ]; then
   echo "Found Ansible role file at $ROLE_REQUIREMENTS"
-  sudo ansible-galaxy install -r ${ROLE_REQUIREMENTS}
+  sudo ansible-galaxy install -r "${ROLE_REQUIREMENTS}"
 fi
 
 # Run the playbook.


### PR DESCRIPTION
This is important in case the filename contains spaces, but more importantly, if no file is set, the test for file existence does not give the desired outcome: [ -f ] evaluates to true/returns an exit code of 0, hence [ -f $VAR ] with $VAR empty does the same. Protecting $VAR with quotes has the desired behaviour.

Not entirely sure whether this is an odd behaviour on my machine, but protecting variables is always a good idea...