### PR TITLE
Add install for gcc to fix the no acceptable C complier found error

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -42,6 +42,12 @@ if ! command -v ansible >/dev/null; then
   # Make sure setuptools are installed crrectly.
   pip install setuptools --no-use-wheel --upgrade
 
+  # install gcc
+  if [[ ! -z $YUM ]]; then
+    yum install -y gcc
+  elif [[ ! -z $APT_GET ]]; then
+    apt-get install -y build-essential
+  fi
   echo "Installing required python modules."
   pip install paramiko pyyaml jinja2 markupsafe
 


### PR DESCRIPTION
With minimal installation of CentOS images, we always encounter the "configure: error: no acceptable C compiler found in $PATH" error while Installing required python modules. 

![image](https://cloud.githubusercontent.com/assets/6635607/9472896/6fc24292-4b8a-11e5-88f4-cccd0410abd7.png)

Add gcc package fixed the issue correctly,

```sh
  # install gcc
  if [[ ! -z $YUM ]]; then
    yum install -y gcc
  elif [[ ! -z $APT_GET ]]; then
    apt-get install -y build-essential
  fi
```