### PR TITLE
Change playbook path not to be prefixed with /vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ if is_windows
   # Provisioning configuration for shell script.
   config.vm.provision "shell" do |sh|
     sh.path = "provisioning/JJG-Ansible-Windows/windows.sh"
-    sh.args = "provisioning/playbook.yml"
+    sh.args = "/vagrant/provisioning/playbook.yml"
   end
 else
   # Provisioning configuration for Ansible (for Mac/Linux hosts).

--- a/windows.sh
+++ b/windows.sh
@@ -34,7 +34,7 @@ YUM=$(which yum 2>/dev/null)
 APT_GET=$(which apt-get 2>/dev/null)
 
 # Make sure Ansible playbook exists.
-if [ ! -f "/vagrant/$ANSIBLE_PLAYBOOK" ]; then
+if [ ! -f "$ANSIBLE_PLAYBOOK" ]; then
   echo "Cannot find Ansible playbook."
   exit 1
 fi
@@ -72,8 +72,8 @@ fi
 
 # Install requirements.
 echo "Installing Ansible roles from requirements file, if available."
-find "/vagrant/$PLAYBOOK_DIR" \( -name "requirements.yml" -o -name "requirements.txt" \) -exec sudo ansible-galaxy install --force --ignore-errors -r {} \;
+find "$PLAYBOOK_DIR" \( -name "requirements.yml" -o -name "requirements.txt" \) -exec sudo ansible-galaxy install --force --ignore-errors -r {} \;
 
 # Run the playbook.
 echo "Running Ansible provisioner defined in Vagrantfile."
-ansible-playbook -i 'localhost,' "/vagrant/${ANSIBLE_PLAYBOOK}" --extra-vars "${extra_vars[*]}" --connection=local
+ansible-playbook -i 'localhost,' "${ANSIBLE_PLAYBOOK}" --extra-vars "${extra_vars[*]}" --connection=local


### PR DESCRIPTION
Both for clarity and flexibility (using `/vagrant` is the default, but it's not enforced by Vagrant).