### PR TITLE
Issue #28: Add missing build dependencies

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -56,11 +56,11 @@ if ! command -v ansible >/dev/null; then
   wget https://bootstrap.pypa.io/get-pip.py
   python get-pip.py && rm -f get-pip.py
 
-  # Install GCC / required build tools.
+  echo "Installing required build tools."
   if [[ ! -z $YUM ]]; then
-    yum install -y gcc
+    yum install -y gcc libffi-devel openssl-devel
   elif [[ ! -z $APT_GET ]]; then
-    apt-get install -y build-essential
+    apt-get install -y build-essential libssl-dev libffi-dev
   fi
 
   echo "Installing required python modules."


### PR DESCRIPTION
Testing this will take all night on my connection. But I'll keep updating the list as I go along (not sure I have time to test all tonight). I'm assuming it should work unless `cryptography` have missed something in their dependency list.

Tested:
- [x] geerlingguy/ubuntu1604
- [x] geerlingguy/ubuntu1404
- [x] geerlingguy/ubuntu1204
- [x] geerlingguy/centos6
- [x] geerlingguy/centos7
